### PR TITLE
CLI smarter target specifying

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,11 @@ yarn add --dev eject-enum
 # if you installed locally, prepend `npx` or `yarn`.
 
 # rewrite all files in projects specified by TS configs.
-eject-enum --project path/to/tsconfig.json path/to/tsconfig2.json
+eject-enum path/to/tsconfig.json path/to/tsconfig2.json
 
 # rewrite all TS files under the `src` and `test` directories,
 # except files under the `src/foo` directory.
-eject-enum --include "src/**/*.ts" "test/**/*.ts" --exclude "src/foo/**/*.ts"
+eject-enum "src/**/*.ts" "test/**/*.ts" --exclude "src/foo/**/*.ts"
 ```
 
 You can execute **eject-enum** from scripts as well.

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -9,8 +9,22 @@ describe("targetFromArgv", () => {
       include: [],
       exclude: [],
     };
-    expect(targetFromArgv(argv)).toEqual(
+    expect(targetFromArgv(argv, [])).toEqual(
       EjectEnumTarget.tsConfig(argv.project)
+    );
+  });
+
+  test("consider JSON files in positional args as TS configs", () => {
+    const argv = {
+      project: ["tsconfig.project.json"],
+      include: [],
+      exclude: [],
+    };
+    expect(targetFromArgv(argv, ["tsconfig.positional.json"])).toEqual(
+      EjectEnumTarget.tsConfig([
+        "tsconfig.project.json",
+        "tsconfig.positional.json",
+      ])
     );
   });
 
@@ -20,10 +34,24 @@ describe("targetFromArgv", () => {
       include: ["src/**/*", "test/**/*"],
       exclude: ["src/hoge/*.ts", "src/fuga.ts"],
     };
-    expect(targetFromArgv(argv)).toEqual(
+    expect(targetFromArgv(argv, [])).toEqual(
       EjectEnumTarget.paths({
         include: argv.include,
         exclude: argv.exclude,
+      })
+    );
+  });
+
+  test("consider non-JSON paths in positional args as include paths", () => {
+    const argv = {
+      project: [],
+      include: ["src/include/**"],
+      exclude: ["src/exclude/**"],
+    };
+    expect(targetFromArgv(argv, ["src/positional/**"])).toEqual(
+      EjectEnumTarget.paths({
+        include: ["src/include/**", "src/positional/**"],
+        exclude: ["src/exclude/**"],
       })
     );
   });
@@ -34,19 +62,35 @@ describe("targetFromArgv", () => {
       include: ["src/**/*", "test/**/*"],
       exclude: ["src/hoge/*.ts", "src/fuga.ts"],
     };
-    expect(targetFromArgv(argv)).toEqual(
+    expect(targetFromArgv(argv, [])).toEqual(
       EjectEnumTarget.tsConfig(argv.project)
     );
   });
 
-  test("throws if neither --project nor --include is specified", () => {
+  test("positionals: JSON files win against non-JSONs", () => {
+    const argv = {
+      project: [],
+      include: [],
+      exclude: [],
+    };
+    expect(
+      targetFromArgv(argv, [
+        "src/hoge/**",
+        "tsconfig.json",
+        "src/fuga/**",
+        "tsconfig2.json",
+      ])
+    ).toEqual(EjectEnumTarget.tsConfig(["tsconfig.json", "tsconfig2.json"]));
+  });
+
+  test("throws if no targets are specified", () => {
     const argv = {
       project: [],
       include: [],
       exclude: ["hoge"],
     };
     expect(() => {
-      targetFromArgv(argv);
+      targetFromArgv(argv, []);
     }).toThrow();
   });
 });


### PR DESCRIPTION
The CLI argument parser now recognize positional arguments as target specifier.

- JSON file paths are considered as TS config paths (like `--project`)
- Non-JSON paths are considered as include paths (like `--include`)
- If both JSON and non-JSON paths are specified, JSON paths take a priority and non-JSON paths are all ignored