### PR TITLE
tsconfig auto detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,14 @@ dx eject-enum [options...]
 CLI Options:
 
 ```bash
-# rewrite all files in projects specified by tsconfigs.
+# If no targets are specified, it tries to use `tsconfig.json` 
+# in the current directory as the default target.
+npx eject-enum
+
+# Rewrite all files in projects specified by tsconfigs.
 npx eject-enum path/to/tsconfig.json path/to/tsconfig2.json
 
-# rewrite all Typescript files under the `src` and `test` directories,
+# Rewrite all Typescript files under the `src` and `test` directories,
 # except files under the `src/foo` directory.
 npx eject-enum "src/**/*.ts" "test/**/*.ts" --exclude "src/foo/**/*.ts"
 ```
@@ -90,7 +94,7 @@ npm install --save-dev eject-enum
 ```ts
 import { ejectEnum, EjectEnumTarget } from "eject-enum";
 
-// rewrite all files in projects specified by paths to tsconfigs.
+// Rewrite all files in projects specified by paths to tsconfigs.
 ejectEnum(
     EjectEnumTarget.projects([
         "path/to/tsconfig.json",
@@ -98,7 +102,7 @@ ejectEnum(
     ]),
 );
 
-// rewrite all Typescript files under the `src` and `test` directories
+// Rewrite all Typescript files under the `src` and `test` directories
 // except files under the `src/foo` directory.
 ejectEnum(
     EjectEnumTarget.srcPaths({

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import path from "node:path";
 import type { Argv as YargsArgv } from "yargs";
 import { hideBin } from "yargs/helpers";
@@ -88,7 +89,14 @@ export function targetFromArgv(
   /* no JSON files are specified in positional args */
 
   if (argv.project.length === 0 && argv.include.length === 0 && nonJsons.length === 0) {
-    throw Error("No targets are specified");
+    // If no target specified and "tsconfig.json" exists in current directory, use it as default target project
+    try {
+      fs.accessSync("tsconfig.json", fs.constants.R_OK);
+      console.log("No target specified, using 'tsconfig.json' of the current directory as the default target project.");
+      return EjectEnumTarget.projects(["tsconfig.json"]);
+    } catch {
+      throw Error("No targets are specified");
+    }
   }
 
   return argv.project.length > 0

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -71,14 +71,12 @@ describe("targetFromArgv", () => {
     );
   });
 
-  test("throws if no targets are specified", () => {
+  test("use tsconfig.json in CWD if no targets are specified", () => {
     const argv = {
       project: [],
       include: [],
-      exclude: ["hoge"],
+      exclude: [],
     };
-    expect(() => {
-      targetFromArgv(argv, []);
-    }).toThrow();
+    expect(targetFromArgv(argv, [])).toEqual(EjectEnumTarget.projects(["tsconfig.json"]));
   });
 });


### PR DESCRIPTION
In CLI usage, make it use "tsconfig.json" in the current directory if no target are specified.

```bash
# "tsconfig.json" in the cwd is default target
npx eject-enum
```